### PR TITLE
Fix comment_carve lexer

### DIFF
--- a/cpp/src/reachability_analyzer.hpp
+++ b/cpp/src/reachability_analyzer.hpp
@@ -130,18 +130,18 @@ class PPRecordNested : public clang::PPCallbacks {
         // input:
         // ```
         // 1|#define MACRO \
-		// 2|"hi"
+        // 2|"hi"
         // ```
         //
         // intended output:
         // ```
         // 1|#define MACRO \
-		// 2|"hi"
+        // 2|"hi"
         //
         /// previous wrong output:
         // ```
         // 1|#define MACRO \
-		// 2|//-"hi"
+        // 2|//-"hi"
         // ```
         //
         // Futhermore, it seems like the PreprocessingRecord is filled up first,

--- a/test/test.ml
+++ b/test/test.ml
@@ -70,6 +70,40 @@ let test_all tests =
 let test_with prefix tests =
   test_all @@ List.map (fun x -> String.concat " " (prefix @ [ x ])) tests
 
+let%expect_test "kept_line" =
+  test_all kept_line;
+  [%expect
+    {|
+      \
+
+      -->
+      \
+
+      ====
+
+
+      -->
+
+
+      ====
+      //
+      -->
+      //
+      ====
+      /*
+      -->
+      /*string:1:2: error: eof in comment
+      ====
+      "
+      -->
+      "string:1:1: error: eof in string
+      ====
+      kept_line
+      -->
+      kept_line
+      ====
+      |}]
+
 let%expect_test "line_start -> _" =
   test_all line_start;
   [%expect


### PR DESCRIPTION
Not sure how I missed this - lines starting with " or /* are now correctly erroring.