### PR TITLE
Remove "conf-clang-12" dependency

### DIFF
--- a/c-tree-carver.opam
+++ b/c-tree-carver.opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.12.0"}
   "conf-c++"
-  "conf-clang-12"
   "conf-cmake" {dev}
   "conf-llvm" {= "12.0.1"}
   "conf-python3" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,6 @@
  (depends
      (ocaml (>= 4.12.0))
      conf-c++
-     conf-clang-12
      (conf-cmake :dev)
      (conf-llvm (= 12.0.1))
      (conf-python3 :with-test)


### PR DESCRIPTION
This was deleted and replaced in
f989088e4c5ccc0c202c18591af1abb2933c1fe2 but accidentally stuck around in the dune-project.